### PR TITLE
use git clone instead of git export

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if cd connfa;
 then 
 	git pull; 
 else 
-	git export https://github.com/lemberg/connfa-integration-server.git connfa
+	git clone https://github.com/lemberg/connfa-integration-server.git connfa
 	cd connfa
 fi
 


### PR DESCRIPTION
install script was returning an error because git export is not a valid git command